### PR TITLE
Add file upload functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ nodeLanguageServer.*/**
 dist/**
 src/__pycache__
 src/challenge.db
+pyproject.toml

--- a/README.md
+++ b/README.md
@@ -103,7 +103,24 @@ There are several types of grading that are supported by this server.
   - In this style of grading, the user is not expected to take any action for grading to occur. Grading happens on an interval and/or at a scheduled time
   - Additional config settings maybe be required for this style to operate to your challenge's specs.
 
-More information about using each grading type is provided in the comments of the [config](./src/config.yml) file.
+More information about using each grading type is provided in the [supplemental readme](./src/README.md).
+
+#### Uploading Files
+
+The Challenge Server allows users to upload files for grading. This type of grading is useful for:
+
+1. Programming exercises where running the user-supplied code can determine if they have met the success conditions
+2. Exercises where parsing a file can determine if the user has met the success conditions
+
+When files are uploaded, the Challenge Server first zips files that are part of the same file set. This allows users to select multiple files to upload, and results in a single zip file being stored on the Challenge Server after upload.
+
+When using the file upload grading type, multiple grading checks can be associated with the same file and multiple files can be associated with one grading check. When uploaded files are associated with a grading check, the Challenge Server will pass the path to the file sets to the grading script as positional arguments.
+
+##### Example
+
+A challenge requires a user to write a Python program that produces an expected output. The user uploads their Python program, consisting of multiple `.py` files in a format that follows the challenge instructions. The grading script will run the Python program in the way that the challenge developer described in the instructions to determine if the uploaded program meets the requirements.
+
+_Caution: Running user-uploaded code can be dangerous. The challenge developer should take necessary security precautions to ensure user-uploaded code/files do not have unintended consequences._
 
 ### Grading Scripts
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The Challenge Server allows users to upload files for grading. This type of grad
 
 When files are uploaded, the Challenge Server first zips files that are part of the same file set. This allows users to select multiple files to upload, and results in a single zip file being stored on the Challenge Server after upload.
 
-When using the file upload grading type, multiple grading checks can be associated with the same file and multiple files can be associated with one grading check. When uploaded files are associated with a grading check, the Challenge Server will pass the path to the file sets to the grading script as positional arguments.
+When using the file upload grading type, multiple grading checks can be associated with the same file and multiple files can be associated with one grading check. When uploaded files are associated with a grading check, the Challenge Server will include the path to the file sets as part of the JSON passed to the grading script as an argument.
 
 ##### Example
 

--- a/src/README.md
+++ b/src/README.md
@@ -154,10 +154,12 @@ Examples can be found in the `services_to_log` section of the `config.yml` file.
   - `text` - Provide the user with a text box to submit an answer.
   - `button` - Provides a button to trigger the grading script.
   - `cron` - Grade automatically on the configured schedule (see `cron_grading` settings).
+  - `upload` - Allow users to upload files that are processed by the grading script.
+    - `upload_key` - Define a set of files that an uploaded file should belong to. This is useful if multiple grading checks are looking at the same file or if multiple uploaded files are associated with one grading check. This value will be used to generate the name of the saved artifact.
   - `mc` - Multiple Choice question.
-  - `opts` -- Multiple choice options. Only applies when question mode is `mc`.
-    - Keys start at `a` and continue in alphabetical order.
-    - Values are the text for each option.
+    - `opts` -- Multiple choice options. Only applies when question mode is `mc`.
+      - Keys start at `a` and continue in alphabetical order.
+      - Values are the text for each option.
 
 ### phases (question sets)
 

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -54,12 +54,16 @@ def create_app(config_class=Config):
         def store_req():
             if (not str(request.path).endswith('.js')) and (not str(request.path).endswith('.css')) and (not str(request.path).endswith('update')):
                 with app.app_context():
-                    event = "Request" if request.method == 'GET' else 'Submission'
+                    event = (
+                        "Request" if request.method == 'GET'
+                        else "Upload" if "upload" in str(request.path)
+                        else "Submission"
+                    )
                     form_data = "No Data Submitted"
                     if len(form_data) > 0:
                         form_data = dict(request.form)
-                        if 'submit' in form_data.keys():
-                            del form_data['submit']
+                        # if 'submit' in form_data.keys():
+                        #     del form_data['submit']
                         for k, v in request.form.items():
                             if k != 'submit':
                                 form_data[f"{k}_text"] = globals.grading_parts[k]['text']
@@ -82,10 +86,10 @@ def create_app(config_class=Config):
                             cur_cnt['number_submissions'] = str(int(cur_cnt['number_submissions'])+1)
                             cur_cnt['recorded_at'] = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
                             sub_obj.data = json.dumps(cur_cnt)
-                            db.session.commit()
                         except Exception as e:
                             logger.error(f"Exception trying increment submission counter. Exception: {str(e)}")
                             sys.exit(1)
+                    db.session.commit()
     return app
 
 def run_startup_scripts():

--- a/src/app/fileUploads.py
+++ b/src/app/fileUploads.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+#
+# Challenge Sever
+# Copyright 2024 Carnegie Mellon University.
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+# Licensed under a MIT (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see Copyright notice for non-US Government use and distribution.
+# DM24-0645
+#
+
+import os, zipfile, tempfile, shutil
+from werkzeug.utils import secure_filename
+from app.extensions import logger, globals, db
+from app.models import FileUpload
+
+
+
+def construct_file_save_path(file_key: str) -> str:
+    """
+    Pick the next ZIP filename for this file_key
+    (e.g. "fileset1_3.zip") and return its full path.
+    """
+    upload_dir = globals.uploaded_file_directory
+    ext        = globals.grading_uploads.get('format', 'zip')
+    os.makedirs(upload_dir, exist_ok=True)
+
+    # increment file name to preserve upload history
+    next_idx = get_latest_submission_number(file_key) + 1
+    filename = f"{file_key}_{next_idx}.{ext}"
+    return os.path.join(upload_dir, filename)
+
+
+def get_latest_submission_number(file_key: str) -> int:
+    """
+    Return the highest submission_number in FileUploads for a given file_key
+    (i.e. filename starting with "<file_key>_"). Returns 0 if none exist.
+    """
+
+    like_pattern = f"{file_key}_%"
+    latest = (
+        FileUpload.query
+        .filter(FileUpload.filename.like(like_pattern))
+        .order_by(FileUpload.submission_number.desc())
+        .first()
+    )
+    return latest.submission_number if latest else 0
+
+
+def get_most_recent_uploads(file_keys: list[str]) -> dict[str, str]:
+    """
+    For each logical key, return the timestamp of its latest ZIP upload
+    (or None). Queries the FileUploads table only.
+    """
+
+    uploads = {}
+    for key in file_keys:
+        latest = (
+            FileUpload.query
+            .filter(FileUpload.filename.like(f"{key}_%"))
+            .order_by(FileUpload.submission_number.desc())
+            .first()
+        )
+        uploads[key] = (
+            latest.uploaded_at.strftime("%Y-%m-%d %H:%M:%S")
+            if latest else None
+        )
+    return uploads
+
+
+def save_uploaded_file(file_key: str, uploaded_files: list[str]):
+    """
+    Save files that are uploaded to the file system and the database
+    """
+
+    next_idx = get_latest_submission_number(file_key) + 1
+    upload_dir = globals.uploaded_file_directory
+    ext        = globals.grading_uploads.get('format', 'zip')
+    os.makedirs(upload_dir, exist_ok=True)
+
+    zip_name = f"{file_key}_{next_idx}.{ext}"
+    zip_path = os.path.join(upload_dir, zip_name)
+
+    # Stream into ZIP and collect inner filenames
+    tmpdir = tempfile.mkdtemp()
+    inner_files = []
+    try:
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for fs in uploaded_files:
+                safe = secure_filename(fs.filename or "")
+                if not safe:
+                    continue
+                inner_files.append(safe)
+                tmp_fp = os.path.join(tmpdir, safe)
+                fs.save(tmp_fp)
+                zf.write(tmp_fp, arcname=safe)
+    finally:
+        shutil.rmtree(tmpdir)
+
+    logger.info(f"Saving uploaded files ({inner_files}) to zip {zip_path}")
+
+    # DB insert
+    new_row = FileUpload(
+        filename           = zip_name,
+        submission_number  = next_idx,
+        contained_files    = inner_files
+    )
+    db.session.add(new_row)
+    db.session.commit()
+
+    return zip_path

--- a/src/app/functions.py
+++ b/src/app/functions.py
@@ -9,15 +9,15 @@
 #
 
 
-import yaml, os, subprocess, requests, datetime, json, sys, ipaddress, zipfile, tempfile, shutil
+import yaml, os, subprocess, requests, datetime, json, sys, ipaddress
 from flask import current_app
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import Future
 from time import sleep
-from werkzeug.utils import secure_filename
 from app.extensions import logger, globals, db, record_solves_lock
 from app.env import get_clean_env
-from app.models import QuestionTracking,PhaseTracking, EventTracker, FileUpload
+from app.models import QuestionTracking,PhaseTracking, EventTracker
+from app.fileUploads import construct_file_save_path
 
 ####### parse `config.yml` and assign values to globals object
 def read_config(app):
@@ -407,95 +407,6 @@ def update_db(type_q,label=None, val=None):
                         globals.current_phase = phase.label
                         return
 
-
-def construct_file_save_path(file_key: str) -> str:
-    """
-    Pick the next ZIP filename for this file_key
-    (e.g. "fileset1_3.zip") and return its full path.
-    """
-    upload_dir = globals.uploaded_file_directory
-    ext        = globals.grading_uploads.get('format', 'zip')
-    os.makedirs(upload_dir, exist_ok=True)
-
-    next_idx = get_latest_submission_number(file_key) + 1
-    filename = f"{file_key}_{next_idx}.{ext}"
-    return os.path.join(upload_dir, filename)
-
-
-
-def get_latest_submission_number(file_key: str) -> int:
-    """
-    Return the highest submission_number in FileUploads for a given file_key
-    (i.e. filename starting with "<file_key>_"). Returns 0 if none exist.
-    """
-
-    like_pattern = f"{file_key}_%"
-    latest = (
-        FileUpload.query
-        .filter(FileUpload.filename.like(like_pattern))
-        .order_by(FileUpload.submission_number.desc())
-        .first()
-    )
-    return latest.submission_number if latest else 0
-
-
-def get_most_recent_uploads(file_keys: list[str]) -> dict[str, str]:
-    """
-    For each logical key, return the timestamp of its latest ZIP upload
-    (or None). Queries the FileUploads table only.
-    """
-    uploads = {}
-    for key in file_keys:
-        latest = (
-            FileUpload.query
-            .filter(FileUpload.filename.like(f"{key}_%"))
-            .order_by(FileUpload.submission_number.desc())
-            .first()
-        )
-        uploads[key] = (
-            latest.uploaded_at.strftime("%Y-%m-%d %H:%M:%S")
-            if latest else None
-        )
-    return uploads
-
-
-
-def save_uploaded_file(file_key: str, uploaded_files: list[str]):
-    # 1) Next index and path
-    next_idx = get_latest_submission_number(file_key) + 1
-    upload_dir = globals.uploaded_file_directory
-    ext        = globals.grading_uploads.get('format', 'zip')
-    os.makedirs(upload_dir, exist_ok=True)
-
-    zip_name = f"{file_key}_{next_idx}.{ext}"
-    zip_path = os.path.join(upload_dir, zip_name)
-
-    # 2) Stream into ZIP and collect inner filenames
-    tmpdir = tempfile.mkdtemp()
-    inner_files = []
-    try:
-        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
-            for fs in uploaded_files:
-                safe = secure_filename(fs.filename or "")
-                if not safe:
-                    continue
-                inner_files.append(safe)
-                tmp_fp = os.path.join(tmpdir, safe)
-                fs.save(tmp_fp)
-                zf.write(tmp_fp, arcname=safe)
-    finally:
-        shutil.rmtree(tmpdir)
-
-    # 3) DB insert
-    new_row = FileUpload(
-        filename           = zip_name,
-        submission_number  = next_idx,
-        contained_files    = inner_files
-    )
-    db.session.add(new_row)
-    db.session.commit()
-
-    return zip_path
 
 #######
 # Grading Functions

--- a/src/app/globals.py
+++ b/src/app/globals.py
@@ -28,7 +28,6 @@ class Globals():
         self.VALID_TOKEN_LOCATIONS = ['env', 'guestinfo', 'file']
         self.VALID_SUBMISSION_METHODS = ['display', 'grader_post']
         self.VALID_SERVICE_TYPES = ['ping', 'socket', 'web']
-        self.VALID_UPLOAD_FORMATS = ['zip']
         # files/directories
         self.basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         self.custom_script_dir = f"{self.basedir}/custom_scripts"

--- a/src/app/globals.py
+++ b/src/app/globals.py
@@ -23,15 +23,17 @@ class Globals():
         self.app_key = None
 
         # From config.yml
-        self.VALID_CONFIG_MODES = ['button', 'cron', 'text', 'text_single', 'mc']
-        self.MANUAL_MODE = ['button', 'text', 'text_single', 'mc']
+        self.VALID_CONFIG_MODES = ['button', 'cron', 'text', 'text_single', 'mc', 'upload']
+        self.MANUAL_MODE = ['button', 'text', 'text_single', 'mc', 'upload']
         self.VALID_TOKEN_LOCATIONS = ['env', 'guestinfo', 'file']
         self.VALID_SUBMISSION_METHODS = ['display', 'grader_post']
         self.VALID_SERVICE_TYPES = ['ping', 'socket', 'web']
+        self.VALID_UPLOAD_FORMATS = ['zip']
         # files/directories
         self.basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         self.custom_script_dir = f"{self.basedir}/custom_scripts"
         self.hosted_file_directory = f"{self.basedir}/hosted_files"
+        self.uploaded_file_directory = f"{self.basedir}/uploaded_files"
         self.yaml_path =  f"{self.basedir}/config.yml"
         # configuration globals
         challenge_id = get_clean_env('CS_ISOLATION_TAG', '')
@@ -99,3 +101,5 @@ class Globals():
         ## Scheduler is referenced when add/pausing/deleting jobs.
         self.scheduler = APScheduler()
         self.challenge_name = ""
+
+        self.grading_uploads = {}

--- a/src/app/main/main.py
+++ b/src/app/main/main.py
@@ -9,11 +9,10 @@
 #
 
 
-import datetime, copy, os, zipfile, tempfile, shutil
+import datetime, copy, os
 from flask import Blueprint, render_template, request, redirect, url_for, send_from_directory, jsonify, flash, g
-from werkzeug.utils import secure_filename
 from app.extensions import logger, globals
-from app.functions import do_grade, check_questions,read_token, construct_file_save_path, get_most_recent_uploads
+from app.functions import do_grade, check_questions,read_token, construct_file_save_path, get_most_recent_uploads, save_uploaded_file
 from app.models import QuestionTracking
 
 main = Blueprint("main",__name__, template_folder='templates', static_folder='static')
@@ -65,18 +64,8 @@ def upload():
             continue
 
         if globals.grading_uploads['format'] == 'zip':
-            temp_dir = tempfile.mkdtemp()
-            zip_path = construct_file_save_path(file_key)
-            with zipfile.ZipFile(zip_path, 'w') as zip_file:
-                for file in uploaded:
-                    filename = secure_filename(file.filename)
-                    if not filename:
-                        continue
-                    filepath = os.path.join(temp_dir, filename)
-                    with open(filepath, 'wb') as f:
-                        file.save(f)
-                    zip_file.write(filepath)
-            shutil.rmtree(temp_dir)
+            zip_path = save_uploaded_file(file_key, uploaded)
+
 
     return tasks()
 

--- a/src/app/main/main.py
+++ b/src/app/main/main.py
@@ -40,8 +40,18 @@ def tasks():
                 parts_org[q_mode][key] = value
         else:
             parts_org[q_mode][key] = value
+    if globals.grading_uploads and 'files' in globals.grading_uploads:
+        files = globals.grading_uploads['files']
+        parts_org['uploads'] = files
+
     return render_template('tasks.html', questions=parts_org)
 
+@main.route('/upload', methods=['POST'])
+def upload():
+    '''
+    Handle saving submitted files.
+    '''
+    print(request.files.getlist("file1"))
 
 @main.route('/grade', methods=['GET', 'POST'])
 def grade():

--- a/src/app/main/main.py
+++ b/src/app/main/main.py
@@ -64,8 +64,7 @@ def upload():
         if not uploaded:
             continue
 
-        if globals.grading_uploads['format'] == 'zip':
-            zip_path = save_uploaded_file(file_key, uploaded)
+        zip_path = save_uploaded_file(file_key, uploaded)
 
 
     return tasks()

--- a/src/app/main/main.py
+++ b/src/app/main/main.py
@@ -73,7 +73,7 @@ def upload():
                     if not filename:
                         continue
                     filepath = os.path.join(temp_dir, filename)
-                    with open(filepath, 'w') as f:
+                    with open(filepath, 'wb') as f:
                         file.save(f)
                     zip_file.write(filepath)
             shutil.rmtree(temp_dir)

--- a/src/app/main/main.py
+++ b/src/app/main/main.py
@@ -12,7 +12,8 @@
 import datetime, copy, os
 from flask import Blueprint, render_template, request, redirect, url_for, send_from_directory, jsonify, flash, g
 from app.extensions import logger, globals
-from app.functions import do_grade, check_questions,read_token, construct_file_save_path, get_most_recent_uploads, save_uploaded_file
+from app.functions import do_grade, check_questions,read_token
+from app.fileUploads import save_uploaded_file, get_most_recent_uploads
 from app.models import QuestionTracking
 
 main = Blueprint("main",__name__, template_folder='templates', static_folder='static')

--- a/src/app/main/main.py
+++ b/src/app/main/main.py
@@ -13,7 +13,7 @@ import datetime, copy, os, zipfile, tempfile, shutil
 from flask import Blueprint, render_template, request, redirect, url_for, send_from_directory, jsonify, flash, g
 from werkzeug.utils import secure_filename
 from app.extensions import logger, globals
-from app.functions import do_grade, check_questions,read_token
+from app.functions import do_grade, check_questions,read_token, construct_file_save_path, get_most_recent_uploads
 from app.models import QuestionTracking
 
 main = Blueprint("main",__name__, template_folder='templates', static_folder='static')
@@ -25,28 +25,6 @@ def pass_globals():
 @main.route('/', methods=['GET'])
 def home():
     return render_template('home.html')
-
-def construct_file_save_path(file_key: str) -> str:
-    file_format = globals.grading_uploads['format']
-    return os.path.join(
-        globals.uploaded_file_directory,
-        '.'.join([file_key, file_format])
-    )
-
-def get_most_recent_uploads(file_keys: list[str]) -> dict[str, str]:
-    '''
-    Get the timestamp of the most recent file upload for each file key in the map.
-    '''
-    most_recent_uploads = {}
-    for key in file_keys:
-        message = "No submissions yet."
-        path = construct_file_save_path(key)
-        if os.path.isfile(path):
-            message = str(datetime.datetime.fromtimestamp(os.path.getmtime(path)))
-        most_recent_uploads[key] = str(message)
-
-    return most_recent_uploads
-
 
 @main.route('/tasks', methods=['GET'])
 def tasks():

--- a/src/app/main/main.py
+++ b/src/app/main/main.py
@@ -121,7 +121,11 @@ def grade():
             # POST requests will several form fields to pass to the grading script
             # Arguments to do_grade are the values from the form fields submitted
             logger.info(f"Calling do_grade with data: {req_data}")
-            globals.task = globals.executor.submit(do_grade, req_data)
+
+            # Make sure the grading script gets all grading check keys even if the user didn't enter anything.
+            user_did_not_submit = {check_name: '' for check_name in globals.grading_parts}
+
+            globals.task = globals.executor.submit(do_grade, user_did_not_submit | req_data)
 
         return render_template('grading.html', submit_time=globals.manual_submit_time)
 

--- a/src/app/main/templates/tasks.html
+++ b/src/app/main/templates/tasks.html
@@ -32,7 +32,7 @@ DM24-0645
         <form id="uploadForm" method="POST" action="{{url_for('main.upload')}}" enctype="multipart/form-data">
             <thead class="res-thead">
                 <th class="q_item1"><label>Task(s)</label></th>
-                <th class="q_item2"><label>File(s)</label></th>
+                <th class="q_item2"><label>Folder</label></th>
                 <th class="q_item3"><label>Last Submission</label></th>
             </thead>
             {% for key, value in questions['new_uploads'].items() %}

--- a/src/app/main/templates/tasks.html
+++ b/src/app/main/templates/tasks.html
@@ -93,6 +93,17 @@ DM24-0645
             </tr>
             {% endfor %}
             {% endif %}
+            {% if 'upload' in questions.keys() %}
+            <tr class="bodypost">
+                <th colspan=2 class="q_long_line">Tasks below will be auto-graded with submitted files</th>
+            </tr>
+            {% for key, value in questions['upload'].items() %}
+            <tr class="bodypost">
+                <td colspan=2 class="q_long_line_q"><label>{{ value['text'] }}</label></td>
+                <td hidden><input type="hidden" name="{{key}}"></td>
+            </tr>
+            {% endfor %}
+            {% endif %}
             {% if 'cron' in questions.keys() %}
             <tr class="bodypost">
                 <th colspan=2 class="q_long_line">Tasks below will be auto-graded

--- a/src/app/main/templates/tasks.html
+++ b/src/app/main/templates/tasks.html
@@ -27,19 +27,19 @@ DM24-0645
 
 <fieldset>
     <!--<legend align='center'>Challenge Questions</legend>-->
-    {% if 'uploads' in questions.keys() %}
+    {% if 'new_uploads' in questions.keys() %}
     <table class="res-table">
         <form id="uploadForm" method="POST" action="{{url_for('main.upload')}}" enctype="multipart/form-data">
             <thead class="res-thead">
                 <th class="q_item1"><label>Task(s)</label></th>
                 <th class="q_item2"><label>File(s)</label></th>
+                <th class="q_item3"><label>Last Submission</label></th>
             </thead>
-            {% for key, value in questions['uploads'].items() %}
+            {% for key, value in questions['new_uploads'].items() %}
             <tr class="bodypost">
                 <td class="q_item1"><label>{{ value['text'] }}</label></td>
-                <td file>
-                    <input type="file" name="{{key}}[]" multiple directory webkitdirectory mozdirectory>
-                </td>
+                <td file><input type="file" name="{{key}}" multiple directory webkitdirectory mozdirectory></td>
+                <td class="q_item3"><label>{{ questions['existing_uploads'][key] }}</label></td>
             </tr>
             {% endfor %}
         </form>

--- a/src/app/main/templates/tasks.html
+++ b/src/app/main/templates/tasks.html
@@ -25,10 +25,32 @@ DM24-0645
     Tasks
 </span>
 
-<form method="POST" action="{{url_for('main.grade')}}" enctype="multipart/form-data" id="min-top-padding">
-    <fieldset>
-        <!--<legend align='center'>Challenge Questions</legend>-->
-        <table class="res-table">
+<fieldset>
+    <!--<legend align='center'>Challenge Questions</legend>-->
+    {% if 'uploads' in questions.keys() %}
+    <table class="res-table">
+        <form id="uploadForm" method="POST" action="{{url_for('main.upload')}}" enctype="multipart/form-data">
+            <thead class="res-thead">
+                <th class="q_item1"><label>Task(s)</label></th>
+                <th class="q_item2"><label>File(s)</label></th>
+            </thead>
+            {% for key, value in questions['uploads'].items() %}
+            <tr class="bodypost">
+                <td class="q_item1"><label>{{ value['text'] }}</label></td>
+                <td file>
+                    <input type="file" name="{{key}}[]" multiple directory webkitdirectory mozdirectory>
+                </td>
+            </tr>
+            {% endfor %}
+        </form>
+    </table>
+    <br>
+    <input type="submit" name="upload" value="Upload Files" form="uploadForm" style="font-size: 20px;">
+    <br>
+    <br>
+    {% endif %}
+    <table class="res-table">
+        <form id="gradeForm" method="POST" action="{{url_for('main.grade')}}" enctype="multipart/form-data">
             {% if 'mc' in questions.keys() %}
             <thead class="res-thead">
                 <th class="q_item1"><label>Question</label></th>
@@ -71,24 +93,6 @@ DM24-0645
             </tr>
             {% endfor %}
             {% endif %}
-            {% if 'uploads' in questions.keys() %}
-            <thead class="res-thead">
-                <th class="q_item1"><label>Task(s)</label></th>
-                <th class="q_item2"><label>File(s)</label></th>
-            </thead>
-            {% for key, value in questions['uploads'].items() %}
-            <tr class="bodypost">
-                <td class="q_item1"><label>{{ value['text'] }}</label></td>
-                <form action="{{url_for('main.upload')}}" method="POST" enctype="multipart/form-data" target="upload-frame">
-                <!-- <form action="{{url_for('main.upload')}}" method="POST" enctype="multipart/form-data"> -->
-                    <td file>
-                        <input type="file" name="{{key}}[]" multiple directory webkitdirectory mozdirectory>
-                        <input type="submit" value="Upload">
-                    </td>
-                </form>
-            </tr>
-            {% endfor %}
-            {% endif %}
             {% if 'cron' in questions.keys() %}
             <tr class="bodypost">
                 <th colspan=2 class="q_long_line">Tasks below will be auto-graded
@@ -105,13 +109,11 @@ DM24-0645
             </tr>
             {% endfor %}
             {% endif %}
-        </table>
-        <br>
-        <input type="submit" name="submit" value="Submit" style="font-size: 20px;">
-    </fieldset>
-</form>
-
-<iframe name="upload-frame" style="display:none;"/>
+        </form>
+    </table>
+    <br>
+    <input type="submit" name="submit" value="Submit" form="gradeForm" style="font-size: 20px;">
+</fieldset>
 {% endif %}
 {% endblock %}
 

--- a/src/app/main/templates/tasks.html
+++ b/src/app/main/templates/tasks.html
@@ -32,13 +32,13 @@ DM24-0645
         <form id="uploadForm" method="POST" action="{{url_for('main.upload')}}" enctype="multipart/form-data">
             <thead class="res-thead">
                 <th class="q_item1"><label>Task(s)</label></th>
-                <th class="q_item2"><label>Folder</label></th>
+                <th class="q_item2"><label>File(s)</label></th>
                 <th class="q_item3"><label>Last Submission</label></th>
             </thead>
             {% for key, value in questions['new_uploads'].items() %}
             <tr class="bodypost">
                 <td class="q_item1"><label>{{ value['text'] }}</label></td>
-                <td file><input type="file" name="{{key}}" multiple directory webkitdirectory mozdirectory></td>
+                <td file><input type="file" name="{{key}}" id="{{key}}" multiple></td>
                 <td class="q_item3"><label>{{ questions['existing_uploads'][key] }}</label></td>
             </tr>
             {% endfor %}

--- a/src/app/main/templates/tasks.html
+++ b/src/app/main/templates/tasks.html
@@ -71,6 +71,24 @@ DM24-0645
             </tr>
             {% endfor %}
             {% endif %}
+            {% if 'uploads' in questions.keys() %}
+            <thead class="res-thead">
+                <th class="q_item1"><label>Task(s)</label></th>
+                <th class="q_item2"><label>File(s)</label></th>
+            </thead>
+            {% for key, value in questions['uploads'].items() %}
+            <tr class="bodypost">
+                <td class="q_item1"><label>{{ value['text'] }}</label></td>
+                <form action="{{url_for('main.upload')}}" method="POST" enctype="multipart/form-data" target="upload-frame">
+                <!-- <form action="{{url_for('main.upload')}}" method="POST" enctype="multipart/form-data"> -->
+                    <td file>
+                        <input type="file" name="{{key}}[]" multiple directory webkitdirectory mozdirectory>
+                        <input type="submit" value="Upload">
+                    </td>
+                </form>
+            </tr>
+            {% endfor %}
+            {% endif %}
             {% if 'cron' in questions.keys() %}
             <tr class="bodypost">
                 <th colspan=2 class="q_long_line">Tasks below will be auto-graded
@@ -92,5 +110,8 @@ DM24-0645
         <input type="submit" name="submit" value="Submit" style="font-size: 20px;">
     </fieldset>
 </form>
+
+<iframe name="upload-frame" style="display:none;"/>
 {% endif %}
 {% endblock %}
+

--- a/src/app/main/templates/tasks.html
+++ b/src/app/main/templates/tasks.html
@@ -33,7 +33,7 @@ DM24-0645
             <thead class="res-thead">
                 <th class="q_item1"><label>Task(s)</label></th>
                 <th class="q_item2"><label>File(s)</label></th>
-                <th class="q_item3"><label>Last Submission</label></th>
+                <th class="q_item3"><label>Last Upload</label></th>
             </thead>
             {% for key, value in questions['new_uploads'].items() %}
             <tr class="bodypost">
@@ -95,7 +95,8 @@ DM24-0645
             {% endif %}
             {% if 'upload' in questions.keys() %}
             <tr class="bodypost">
-                <th colspan=2 class="q_long_line">Tasks below will be auto-graded with submitted files</th>
+                <th colspan=2 class="q_long_line">Tasks below will be graded using uploaded files when "Submit" is
+                    pressed</th>
             </tr>
             {% for key, value in questions['upload'].items() %}
             <tr class="bodypost">
@@ -127,4 +128,3 @@ DM24-0645
 </fieldset>
 {% endif %}
 {% endblock %}
-

--- a/src/app/main/templates/tasks.html
+++ b/src/app/main/templates/tasks.html
@@ -45,7 +45,7 @@ DM24-0645
         </form>
     </table>
     <br>
-    <input type="submit" name="upload" value="Upload Files" form="uploadForm" style="font-size: 20px;">
+    <input type="submit" name="submit" value="Upload Files" form="uploadForm" style="font-size: 20px;">
     <br>
     <br>
     {% endif %}

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -10,6 +10,8 @@
 
 
 from app.extensions import db
+from sqlalchemy import func, JSON
+
 
 class QuestionTracking(db.Model):
     __tablename__ = 'QuestionTracking'
@@ -41,3 +43,24 @@ class EventTracker(db.Model):
     __tablename__ = 'EventTracker'
     id = db.Column(db.Integer, primary_key=True,autoincrement=True)
     data = db.Column(db.String, nullable=False)
+
+
+class FileUpload(db.Model):
+    __tablename__ = 'FileUploads'
+
+    id            = db.Column(db.Integer, primary_key=True)
+    filename      = db.Column(db.String,  nullable=False)
+    submission_number = db.Column(db.Integer, nullable=False)
+    uploaded_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        server_default = func.now()
+    )
+    contained_files   = db.Column(
+                        JSON,
+                        nullable=False,
+                        default=list
+                    )
+
+    def to_dict(self):
+        return {c.name: getattr(self, c.name) for c in self.__table__.columns}

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -49,7 +49,8 @@ class FileUpload(db.Model):
     __tablename__ = 'FileUploads'
 
     id            = db.Column(db.Integer, primary_key=True)
-    filename      = db.Column(db.String,  nullable=False)
+    file_name      = db.Column(db.String,  nullable=False)
+    file_path           = db.Column(db.String,  nullable=False)
     submission_number = db.Column(db.Integer, nullable=False)
     uploaded_at = db.Column(
         db.DateTime(timezone=True),

--- a/src/config.yml
+++ b/src/config.yml
@@ -125,43 +125,43 @@ grading:
   #   phase1: ["GradingCheck1"]
   #   phase2: ["GradingCheck2"]
 
-  # Example for file upload submissions.
+  # Example for folder upload submissions.
   # uploads:
   #   files:
-  #     file1: 
+  #     folder1: 
   #       text: "Submission for parts 1, 2, and 3"
-  #     file2: 
+  #     folder2: 
   #       text: "Submission for parts 4, 5, and 6"
-  #   format: zip # Archive format to save each file bundle as - "zip" is the only one for now.
+  #   format: zip # Archive format to save each folder as - "zip" is the only one for now.
   #   max_upload_size: "1M" # "8000" for 8000 bytes, "10K" for 10 kilobytes, "2G" for gigabytes.
   # parts:
   #   GradingCheck1:
   #     token_name: token1
   #     text: "Question 1: Implement the `part1()` function"
-  #     upload_key: file1
+  #     upload_key: folder1
   #     mode: upload
   #   GradingCheck2:
   #     token_name: token2
   #     text: "Question 2: Implement the `part2()` function"
-  #     upload_key: file1
+  #     upload_key: folder1
   #     mode: upload
   #   GradingCheck3:
   #     token_name: token3
   #     text: "Question 3: Implement the `part3()` function"
-  #     upload_key: file1
+  #     upload_key: folder1
   #     mode: upload
   #   GradingCheck4:
   #     token_name: token4
   #     text: "Question 4: Implement the `part4()` function"
-  #     upload_key: file2
+  #     upload_key: folder2
   #     mode: upload
   #   GradingCheck5:
   #     token_name: token5
   #     text: "Question 5: Implement the `part5()` function"
-  #     upload_key: file2
+  #     upload_key: folder2
   #     mode: upload
   #   GradingCheck6:
   #     token_name: token6
   #     text: "Question 6: Implement the `part6()` function"
-  #     upload_key: file2
+  #     upload_key: folder2
   #     mode: upload

--- a/src/config.yml
+++ b/src/config.yml
@@ -79,6 +79,15 @@ grading:
   rate_limit: 0
   token_location: env
 
+  uploads: # Comment or remove the uploads section to disable uploads.
+    files:
+      file1: 
+        text: "Submission for parts 1, 2, and 3"
+      file2: 
+        text: "Submission for parts 4, 5, and 6"
+    format: zip # "zip" is the only one for now.
+    max_upload_size: "1M" # "8000" for 8000 bytes, "10K" for 10 kilobytes, "2G" for gigabytes.
+
   submission:
     method: display
     grader_url: ""
@@ -106,6 +115,11 @@ grading:
       token_name: token4
       text: "Question 4: Enter 'test4' to pass"
       mode: text
+    GradingCheck5:
+      token_name: token5
+      text: "Question 5: Implement the `fun()` function"
+      upload_key: file1
+      mode: upload
 
   phases: false
 

--- a/src/config.yml
+++ b/src/config.yml
@@ -70,7 +70,7 @@ grading:
   manual_grading: true
   manual_grading_script: manualGradingExample.py
   # manual_grading_script: manualPhasedGradingExample.py # Use this example when doing phased-grading
-  # manual_grading_script: fileUploadExample.py
+  # manual_grading_script: fileUploadExample.py  # Use this example when doing file upload grading
   cron_grading: false
   cron_grading_script: null
   cron_interval: 5
@@ -85,7 +85,7 @@ grading:
     grader_url: ""
     grader_key: ""
 
-# This is a non-phased example
+  # This is a non-phased example
   parts:
     GradingCheck1:
       token_name: token1
@@ -107,7 +107,6 @@ grading:
       token_name: token4
       text: "Question 4: Enter 'test4' to pass"
       mode: text
-
   phases: false
 
   # This is a phased example
@@ -125,12 +124,12 @@ grading:
   #   phase1: ["GradingCheck1"]
   #   phase2: ["GradingCheck2"]
 
-  # Example for multi-file upload submissions.
+  # This is a multi-file upload example
   # uploads:
   #   files:
-  #     fileset1: 
+  #     fileset1:
   #       text: "Submission for parts 1, 2, and 3"
-  #     fileset2: 
+  #     fileset2:
   #       text: "Submission for parts 4, 5, and 6"
   #   format: zip # Archive format to save each folder as - "zip" is the only one for now.
   #   max_upload_size: "1M" # "8000" for 8000 bytes, "10K" for 10 kilobytes, "2G" for gigabytes.

--- a/src/config.yml
+++ b/src/config.yml
@@ -70,6 +70,7 @@ grading:
   manual_grading: true
   manual_grading_script: manualGradingExample.py
   # manual_grading_script: manualPhasedGradingExample.py # Use this example when doing phased-grading
+  # manual_grading_script: fileUploadExample.py
   cron_grading: false
   cron_grading_script: null
   cron_interval: 5
@@ -78,15 +79,6 @@ grading:
   cron_limit: null
   rate_limit: 0
   token_location: env
-
-  uploads: # Comment or remove the uploads section to disable uploads.
-    files:
-      file1: 
-        text: "Submission for parts 1, 2, and 3"
-      file2: 
-        text: "Submission for parts 4, 5, and 6"
-    format: zip # Archive format to save each file bundle as - "zip" is the only one for now.
-    max_upload_size: "1M" # "8000" for 8000 bytes, "10K" for 10 kilobytes, "2G" for gigabytes.
 
   submission:
     method: display
@@ -115,11 +107,6 @@ grading:
       token_name: token4
       text: "Question 4: Enter 'test4' to pass"
       mode: text
-    GradingCheck5:
-      token_name: token5
-      text: "Question 5: Implement the `fun()` function"
-      upload_key: file1
-      mode: upload
 
   phases: false
 
@@ -133,8 +120,48 @@ grading:
   #     token_name: example-token2
   #     text: "Question 2: Enter 'test2' to pass"
   #     mode: text
-
   # phases: true
   # phase_info:
   #   phase1: ["GradingCheck1"]
   #   phase2: ["GradingCheck2"]
+
+  # Example for file upload submissions.
+  # uploads:
+  #   files:
+  #     file1: 
+  #       text: "Submission for parts 1, 2, and 3"
+  #     file2: 
+  #       text: "Submission for parts 4, 5, and 6"
+  #   format: zip # Archive format to save each file bundle as - "zip" is the only one for now.
+  #   max_upload_size: "1M" # "8000" for 8000 bytes, "10K" for 10 kilobytes, "2G" for gigabytes.
+  # parts:
+  #   GradingCheck1:
+  #     token_name: token1
+  #     text: "Question 1: Implement the `part1()` function"
+  #     upload_key: file1
+  #     mode: upload
+  #   GradingCheck2:
+  #     token_name: token2
+  #     text: "Question 2: Implement the `part2()` function"
+  #     upload_key: file1
+  #     mode: upload
+  #   GradingCheck3:
+  #     token_name: token3
+  #     text: "Question 3: Implement the `part3()` function"
+  #     upload_key: file1
+  #     mode: upload
+  #   GradingCheck4:
+  #     token_name: token4
+  #     text: "Question 4: Implement the `part4()` function"
+  #     upload_key: file2
+  #     mode: upload
+  #   GradingCheck5:
+  #     token_name: token5
+  #     text: "Question 5: Implement the `part5()` function"
+  #     upload_key: file2
+  #     mode: upload
+  #   GradingCheck6:
+  #     token_name: token6
+  #     text: "Question 6: Implement the `part6()` function"
+  #     upload_key: file2
+  #     mode: upload

--- a/src/config.yml
+++ b/src/config.yml
@@ -125,12 +125,12 @@ grading:
   #   phase1: ["GradingCheck1"]
   #   phase2: ["GradingCheck2"]
 
-  # Example for folder upload submissions.
+  # Example for multi-file upload submissions.
   # uploads:
   #   files:
-  #     folder1: 
+  #     fileset1: 
   #       text: "Submission for parts 1, 2, and 3"
-  #     folder2: 
+  #     fileset2: 
   #       text: "Submission for parts 4, 5, and 6"
   #   format: zip # Archive format to save each folder as - "zip" is the only one for now.
   #   max_upload_size: "1M" # "8000" for 8000 bytes, "10K" for 10 kilobytes, "2G" for gigabytes.
@@ -138,30 +138,30 @@ grading:
   #   GradingCheck1:
   #     token_name: token1
   #     text: "Question 1: Implement the `part1()` function"
-  #     upload_key: folder1
+  #     upload_key: fileset1
   #     mode: upload
   #   GradingCheck2:
   #     token_name: token2
   #     text: "Question 2: Implement the `part2()` function"
-  #     upload_key: folder1
+  #     upload_key: fileset1
   #     mode: upload
   #   GradingCheck3:
   #     token_name: token3
   #     text: "Question 3: Implement the `part3()` function"
-  #     upload_key: folder1
+  #     upload_key: fileset1
   #     mode: upload
   #   GradingCheck4:
   #     token_name: token4
   #     text: "Question 4: Implement the `part4()` function"
-  #     upload_key: folder2
+  #     upload_key: fileset2
   #     mode: upload
   #   GradingCheck5:
   #     token_name: token5
   #     text: "Question 5: Implement the `part5()` function"
-  #     upload_key: folder2
+  #     upload_key: fileset2
   #     mode: upload
   #   GradingCheck6:
   #     token_name: token6
   #     text: "Question 6: Implement the `part6()` function"
-  #     upload_key: folder2
+  #     upload_key: fileset2
   #     mode: upload

--- a/src/config.yml
+++ b/src/config.yml
@@ -85,7 +85,7 @@ grading:
         text: "Submission for parts 1, 2, and 3"
       file2: 
         text: "Submission for parts 4, 5, and 6"
-    format: zip # "zip" is the only one for now.
+    format: zip # Archive format to save each file bundle as - "zip" is the only one for now.
     max_upload_size: "1M" # "8000" for 8000 bytes, "10K" for 10 kilobytes, "2G" for gigabytes.
 
   submission:

--- a/src/config.yml
+++ b/src/config.yml
@@ -131,7 +131,6 @@ grading:
   #       text: "Submission for parts 1, 2, and 3"
   #     fileset2:
   #       text: "Submission for parts 4, 5, and 6"
-  #   format: zip # Archive format to save each folder as - "zip" is the only one for now.
   #   max_upload_size: "1M" # "8000" for 8000 bytes, "10K" for 10 kilobytes, "2G" for gigabytes.
   # parts:
   #   GradingCheck1:

--- a/src/custom_scripts/fileUploadExample.py
+++ b/src/custom_scripts/fileUploadExample.py
@@ -4,10 +4,10 @@ import sys
 from zipfile import ZipFile
 
 
-def grade_file(filepath):
+def grade_folder_archive(archive_path):
     file_contents = []
-    if os.path.isfile(filepath):
-        with ZipFile(filepath) as arc:
+    if os.path.isfile(archive_path):
+        with ZipFile(archive_path) as arc:
             for filename in arc.namelist():
                 with arc.open(filename) as f:
                     # Do something with the file
@@ -22,7 +22,7 @@ def grade(submission=None):
     results = {}
 
     for check, value in submission.items():
-        results[check] = grade_file(value)
+        results[check] = grade_folder_archive(value)
 
     return results
 

--- a/src/custom_scripts/fileUploadExample.py
+++ b/src/custom_scripts/fileUploadExample.py
@@ -1,0 +1,37 @@
+import json
+import os
+import sys
+from zipfile import ZipFile
+
+
+def grade_file(filepath):
+    file_contents = []
+    if os.path.isfile(filepath):
+        with ZipFile(filepath) as arc:
+            for filename in arc.namelist():
+                with arc.open(filename) as f:
+                    # Do something with the file
+                    # arc.open opens the file in bytes mode, so if we're expecting strings
+                    # we'll need to decode to UTF-8 (Python string)
+                    file_contents.append(f.read().decode())
+        return f"Success - {' | '.join(file_contents)}"
+    return "Failure - you didn't submit any files for this part"
+
+
+def grade(submission=None):
+    results = {}
+
+    for check, value in submission.items():
+        results[check] = grade_file(value)
+
+    return results
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    submissions = json.loads(args[0]) if args else None
+    results = dict()
+    results.update(grade(submissions))
+
+    for key, value in results.items():
+        print(key, " : ", value)

--- a/src/custom_scripts/fileUploadExample.py
+++ b/src/custom_scripts/fileUploadExample.py
@@ -4,7 +4,7 @@ import sys
 from zipfile import ZipFile
 
 
-def grade_folder_archive(archive_path):
+def grade_archive(archive_path):
     file_contents = []
     if os.path.isfile(archive_path):
         with ZipFile(archive_path) as arc:
@@ -22,7 +22,7 @@ def grade(submission=None):
     results = {}
 
     for check, value in submission.items():
-        results[check] = grade_folder_archive(value)
+        results[check] = grade_archive(value)
 
     return results
 

--- a/src/custom_scripts/manualGradingExample.py
+++ b/src/custom_scripts/manualGradingExample.py
@@ -42,13 +42,6 @@ def grade(submission=None):
     else:
         results['GradingCheck4'] = "Failure"
 
-    gc5_path = submission['GradingCheck5']
-    # This one should be a file path, but the file won't exist if the user hasn't submitted yet.
-    if os.path.isfile(gc5_path):
-        results['GradingCheck5'] = "Success"
-    else:
-        results['GradingCheck5'] = "Failure"
-
     return results
 
 

--- a/src/custom_scripts/manualGradingExample.py
+++ b/src/custom_scripts/manualGradingExample.py
@@ -12,7 +12,7 @@
 # Please reference `grading_README.md` to understand grading script requirements.
 #####
 
-import json, sys
+import json, sys, os
 
 # 'submission' will contain text submitted to the question by the user
 def grade(submission=None):
@@ -41,6 +41,13 @@ def grade(submission=None):
         results['GradingCheck4'] = "Success"
     else:
         results['GradingCheck4'] = "Failure"
+
+    gc5_path = submission['GradingCheck5']
+    # This one should be a file path, but the file won't exist if the user hasn't submitted yet.
+    if os.path.isfile(gc5_path):
+        results['GradingCheck5'] = "Success"
+    else:
+        results['GradingCheck5'] = "Failure"
 
     return results
 


### PR DESCRIPTION
- Config file shows the expected formatting for what files can be uploaded (under the `grading` key):
```python
  uploads: # Comment or remove the uploads section to disable uploads.
    files:
      file1: 
        text: "Submission for parts 1, 2, and 3"
      file2: 
        text: "Submission for parts 4, 5, and 6"
    max_upload_size: "1M" # "8000" for 8000 bytes, "10K" for 10 kilobytes, "2G" for gigabytes
```
- User can multi-select files to upload for each key under `files`.
- Server will pack all files into a zip for storage on the file system.
  - Maintains history of each file submitted on the file system.
- A grading check can have the `upload` mode specified with one of the keys under `uploads.files` specified:
```python
    GradingCheck5:
      token_name: token5
      text: "Question 5: Implement the `fun()` function"
      upload_key: file1
      mode: upload
```
- `upload` grading checks get a path to the upload archive added to grading script arguments.
- Also fixes a bug where grading check keys were not sent to the grading script, causing `KeyError`s in the example grading script.