### PR TITLE
Fix display bug when no results yet

### DIFF
--- a/src/app/main/static/js/results.js
+++ b/src/app/main/static/js/results.js
@@ -17,6 +17,7 @@
                 res = JSON.parse(this.responseText);
 
                 var data = document.getElementById('results');
+                data.innerHTML = '';             // remove existing content
 
                 if (res.fatal_error === true) {
                     err_check = document.getElementById('err');


### PR DESCRIPTION
There was a bug that caused "No grades yet" to be appended to the results page on each update poll.  This removes the text duplication on each update.