### PR TITLE
Fix token_location configuration handling

### DIFF
--- a/src/app/globals.py
+++ b/src/app/globals.py
@@ -337,6 +337,11 @@ class Globals:
         self.hosted_files_enabled = self.resolve_bool('CS_HOSTED_FILES', conf.get('hosted_files'), False)
         self.info_home_enabled = self.resolve_bool('CS_INFO_HOME_ENABLED', conf.get('info_and_services'), False)
         self.services_home_enabled = self.resolve_bool('CS_SERVICES_HOME_ENABLED', conf.get('info_and_services'), False)
+        self.token_location = self.resolve(
+            'CS_TOKEN_LOCATION',
+            conf.get('grading', {}).get('token_location'),
+            self.token_location,
+        )
 
         # Load xAPI configuration
         xapi_conf = conf.get('xapi', {}) or {}


### PR DESCRIPTION
This PR fixes a gap between the documented configuration behavior and the current implementation.

The README documents both grading.token_location and CS_TOKEN_LOCATION as supported ways to control where grading tokens are read from: env, guestinfo, or file. However, Globals.load_config() never applied either setting, so self.token_location always stayed at its initialized default.

This change resolves token_location in Globals.load_config() using the existing precedence pattern:

1. CS_TOKEN_LOCATION
2. grading.token_location
3. existing default value

This does not introduce a new feature; it makes the implementation match the documented behavior. Existing deployments that rely on the default env behavior remain unchanged unless they explicitly configure a different token source.

Testing
Verified expected behavior for:
- no token_location configured: default remains unchanged
- grading.token_location: guestinfo: runtime uses guestinfo
- CS_TOKEN_LOCATION=file: environment override wins over config